### PR TITLE
Feature/number keyboard on mobile for distance input

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -7,7 +7,7 @@ const nextConfig = {
   experimental: {
     reactCompiler: true,
   },
-  pageExtensions: ['mdx', 'tsx', 'ts'],
+  pageExtensions: ['mdx', 'tsx'],
 };
 
 module.exports = withMDX(nextConfig);


### PR DESCRIPTION
* Moving the distance input below the faction select
* mobile (tested on iOS) website now pops up a number keyboard instead of full keyboard